### PR TITLE
Pull updates via tracking branch

### DIFF
--- a/lib/tool_belt/release_environment.rb
+++ b/lib/tool_belt/release_environment.rb
@@ -30,6 +30,7 @@ module ToolBelt
 
             if output.include?(repo[:branch])
               @systools.execute("git checkout #{repo[:branch]}")
+              @systools.execute("git pull")
             else
               @systools.execute("git checkout -b #{repo[:branch]}")
             end


### PR DESCRIPTION
When setup-environment is called again, the repos may already exist
with outdated branches.