### PR TITLE
Fix read error when release cache is missing

### DIFF
--- a/lib/tool_belt/issue_cache.rb
+++ b/lib/tool_belt/issue_cache.rb
@@ -45,7 +45,7 @@ module ToolBelt
                        end
 
       issues = project.get_issues_for_release(redmine_release_id)
-      issue_ids = issues.collect { |issue| issue['id'] } - release_manifest[:issues]
+      issue_ids = issues.collect { |issue| issue['id'] } - cache_manifest[:issues]
 
       issue_ids.each do |id|
         issue = add_revisions(id)


### PR DESCRIPTION
On the first run when no release cache exists, don't call
`release_manifest` as the file read will fail.

    lib/ruby/2.0.0/psych.rb:299:in `initialize': No such file or directory - .cache/releases/foreman_1.11.0_issues.yaml (Errno::ENOENT)
        from lib/ruby/2.0.0/psych.rb:299:in `open'
        from lib/ruby/2.0.0/psych.rb:299:in `load_file'
        from tool_belt/lib/tool_belt/issue_cache.rb:69:in `release_manifest'
        from tool_belt/lib/tool_belt/issue_cache.rb:48:in `cache_issues'
        from tool_belt/lib/tool_belt/issue_cache.rb:27:in `load_issues'
        from tool_belt/lib/tool_belt/commands/cherry_pick_command.rb:13:in `execute'