### PR TITLE
Allow ignores list to contain git revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ The release configuration file maintains information about the release including
       - 7423
       - 8265
       - 7815
+
+The `:ignores` list can be a list of Redmine ticket IDs, or a hash of ticket IDs to git revisions to ignore. This allows for only certain commits on a ticket to be ignored.
+
+    :ignores:
+      7423:
+        - d29a748f6653bcae41272d9faa1aae61a4bcfb6e
+      8265:   # ignores all revisions

--- a/lib/tool_belt/cherry_picker.rb
+++ b/lib/tool_belt/cherry_picker.rb
@@ -50,8 +50,12 @@ module ToolBelt
       }
     end
 
-    def ignore?(id)
-      ignores.include?(id) if ignores
+    def ignore?(id, revision)
+      if ignores && ignores.is_a?(Hash)
+        ignores.has_key?(id) && (ignores[id].nil? || ignores[id].include?(revision))
+      elsif ignores
+        ignores.include?(id)
+      end
     end
 
     def write_cherry_pick_log(picks, release)
@@ -76,7 +80,7 @@ module ToolBelt
         missing_string << "----------------------------------------------"
 
         value.each do |pick|
-          if ignore?(pick['id'])
+          if ignore?(pick['id'], pick['revision'])
             ignore_string << log_entry(pick)
           else
             missing_string << log_entry(pick)


### PR DESCRIPTION
The ignores list in configs/ may now be a hash of ticket IDs to a list
of git revisions to permit more precise ignoring. When a ticket contains
multiple revisions from different projects, this prevents each revision
to be ignored without the danger of missing new commits against the
ticket.