### PR TITLE
Fixing incorrect import

### DIFF
--- a/lib/tool_belt/commands/pulp_repository_updater_command.rb
+++ b/lib/tool_belt/commands/pulp_repository_updater_command.rb
@@ -4,7 +4,7 @@ module ToolBelt
   module Command
     class PulpRepositoryUpdateCommand < Clamp::Command
 
-      include CommitOption
+      include ToolsOption
 
       parameter "katello_version", "Katello version of Pulp to compare against"
       parameter "pulp_version", "Pulp stable version to compare against"


### PR DESCRIPTION
The 'CommitOption' was renamed to 'ToolsOption' in a prior commit.